### PR TITLE
File sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An Incus-oriented Windows VMs imaging toolset.
 - High-performance power configuration.
 - Most/all drivers installed.
 - Serial console access (disabled by default).
+- Sharing host directory with guest.
 
 
 ## Supported versions

--- a/local/winfsp.ps1
+++ b/local/winfsp.ps1
@@ -3,7 +3,6 @@
 echo "Enable the VirtIO File System Service"
 $serviceName = 'VirtioFsSvc'
 Set-Service -Name $serviceName -StartupType 'Automatic'
-Start-Service -Name $serviceName
 
 echo "Download and install WinFSP"
 Invoke-WebRequest -Uri 'https://github.com/winfsp/winfsp/releases/download/v2.0/winfsp-2.0.23075.msi' -OutFile 'C:\winfsp-2.0.23075.msi'

--- a/local/winfsp.ps1
+++ b/local/winfsp.ps1
@@ -1,3 +1,5 @@
+# https://blog.simos.info/how-to-run-a-windows-virtual-machine-on-incus-on-linux/#bonus-material-4-how-to-mount-a-directory-from-the-host-to-the-windows-vm
+
 echo "Enable the VirtIO File System Service"
 $serviceName = 'VirtioFsSvc'
 Set-Service -Name $serviceName -StartupType 'Automatic'

--- a/local/winfsp.ps1
+++ b/local/winfsp.ps1
@@ -1,0 +1,9 @@
+echo "Enable the VirtIO File System Service"
+$serviceName = 'VirtioFsSvc'
+Set-Service -Name $serviceName -StartupType 'Automatic'
+Start-Service -Name $serviceName
+
+echo "Download and install WinFSP"
+Invoke-WebRequest -Uri 'https://github.com/winfsp/winfsp/releases/download/v2.0/winfsp-2.0.23075.msi' -OutFile 'C:\winfsp-2.0.23075.msi'
+Start-Process 'C:\winfsp-2.0.23075.msi' -ArgumentList '/passive' -Wait
+

--- a/unattend/10e/Autounattend.xml
+++ b/unattend/10e/Autounattend.xml
@@ -213,7 +213,13 @@
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
           <Order>8</Order>
-          <Description>Enable WinRM</Description>
+          <Description>Download and Install WinFSP</Description>
+          <CommandLine>cmd.exe /c powershell -File F:\local\winfsp.ps1</CommandLine>
+          <RequiresUserInput>false</RequiresUserInput>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>99</Order>
+          <Description>Run sysprep</Description>
           <CommandLine>cmd.exe /c F:\local\sysprepf.bat</CommandLine>
           <RequiresUserInput>true</RequiresUserInput>
         </SynchronousCommand>

--- a/unattend/2012/Autounattend.xml
+++ b/unattend/2012/Autounattend.xml
@@ -235,6 +235,12 @@
           <RequiresUserInput>true</RequiresUserInput>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
+          <Order>10</Order>
+          <Description>Download and Install WinFSP</Description>
+          <CommandLine>cmd.exe /c powershell -File F:\local\winfsp.ps1</CommandLine>
+          <RequiresUserInput>false</RequiresUserInput>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
           <Order>99</Order>
           <Description>Run sysprep</Description>
           <CommandLine>cmd.exe /c E:\local\sysprep.bat</CommandLine>

--- a/unattend/2016/Autounattend.xml
+++ b/unattend/2016/Autounattend.xml
@@ -225,6 +225,12 @@
           <RequiresUserInput>true</RequiresUserInput>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
+          <Order>10</Order>
+          <Description>Download and Install WinFSP</Description>
+          <CommandLine>cmd.exe /c powershell -File F:\local\winfsp.ps1</CommandLine>
+          <RequiresUserInput>false</RequiresUserInput>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
           <Order>99</Order>
           <Description>Run sysprep</Description>
           <CommandLine>cmd.exe /c E:\local\sysprep.bat</CommandLine>

--- a/unattend/2019/Autounattend.xml
+++ b/unattend/2019/Autounattend.xml
@@ -225,6 +225,12 @@
           <RequiresUserInput>true</RequiresUserInput>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
+          <Order>10</Order>
+          <Description>Download and Install WinFSP</Description>
+          <CommandLine>cmd.exe /c powershell -File F:\local\winfsp.ps1</CommandLine>
+          <RequiresUserInput>false</RequiresUserInput>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
           <Order>99</Order>
           <Description>Run sysprep</Description>
           <CommandLine>cmd.exe /c F:\local\sysprepf.bat</CommandLine>

--- a/unattend/2022/Autounattend.xml
+++ b/unattend/2022/Autounattend.xml
@@ -225,6 +225,12 @@
           <RequiresUserInput>true</RequiresUserInput>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
+          <Order>10</Order>
+          <Description>Download and Install WinFSP</Description>
+          <CommandLine>cmd.exe /c powershell -File F:\local\winfsp.ps1</CommandLine>
+          <RequiresUserInput>false</RequiresUserInput>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
           <Order>99</Order>
           <Description>Run sysprep</Description>
           <CommandLine>cmd.exe /c F:\local\sysprepf.bat</CommandLine>


### PR DESCRIPTION
Adds the ability to share a directory on the Linux host with the Windows guest using the [incus config device add command](https://linuxcontainers.org/incus/docs/main/reference/manpages/incus/config/device/add/).

Sourced from https://blog.simos.info/how-to-run-a-windows-virtual-machine-on-incus-on-linux/#bonus-material-4-how-to-mount-a-directory-from-the-host-to-the-windows-vm