### PR TITLE
Terminate the child process running `incus start --console` when it's no longer required and wait for it to finish before displaying further messages in parent process

### DIFF
--- a/tools/click.py
+++ b/tools/click.py
@@ -36,6 +36,12 @@ else:
         os.write(fd, b'\r\n')
         time.sleep(1)
 
+    print('[+] Terminate incus start console...')
+    os.kill(pid, 15)
+    try:
+        os.waitpid(pid, 0)
+    except ChildProcessError as e:
+        print(f'[+] {e}')
 
 print('[+] Letting the installer do its thing...')
 print('[+] Waiting for the VM to be stopped for 10 seconds')


### PR DESCRIPTION
Fixes #9 

After to start console has been spammed with Enter to 10s, we no longer need it.  So might as well terminate the child process running `incus start --console` and then display the messages that follow in the parent process, such as the message about "You may connect to the VM's VGA using the following command"

Testing:
```
$ sh build.sh 10e
[+] Downloading virtio drivers for Windows
[+] Downloading Windows ISO file
[+] Building image
[+] Repacking ISO with unattended data
xorriso 1.5.4 : RockRidge filesystem manipulator, libburnia project.

xorriso 1.5.4 : RockRidge filesystem manipulator, libburnia project.

Drive current: -outdev 'stdio:/home/kim/github/incus-windows/output/win10e/unattended-10e.iso'
Media current: stdio file, overwriteable
Media status : is blank
Media summary: 0 sessions, 0 data blocks, 0 data, 75.3g free
Added to ISO image: directory '/'='/home/kim/github/incus-windows/tmp/virtio-win-10e'
xorriso : UPDATE :    1948 files added in 1 seconds
xorriso : UPDATE :    1948 files added in 1 seconds
xorriso : UPDATE :  11.18% done
xorriso : UPDATE :  72.06% done
ISO image produced: 617898 sectors
Written to medium : 617898 sectors at LBA 0
Writing to 'stdio:/home/kim/github/incus-windows/output/win10e/unattended-10e.iso' completed successfully.

[+] Launching the VM
Creating buildab1f330b0a21
Device iso added to buildab1f330b0a21
[+] Spamming Enter for 10 seconds
[+] Terminate incus start console...
[+] Letting the installer do its thing...
[+] Waiting for the VM to be stopped for 10 seconds
[+] You may connect to the VM's VGA using the following command
incus console --type=vga buildab1f330b0a21
[+] VM stopped
[+] Converting the VM to an image
Publishing instance: Exporting: 16%
```