### PR TITLE
Bump virtio-win to 0.1.285, and add viosock driver for win10e. 

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,4 +1,21 @@
 VIRTIO_ARCHIVE="${VIRTIO_ARCHIVE:-https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/}"
 # 0.1.262-1 breaks 2012
-VIRTIO_VERSION="${VIRTIO_VERSION:-0.1.248-1}"
-VIRTIO_SHA256="${VIRTIO_SHA256:-d5b5739cf297f0538d263e30678d5a09bba470a7c6bcbd8dff74e44153f16549}"
+VIRTIO_VERSION_DEFAULT="${VIRTIO_VERSION_DEFAULT:-0.1.248-1}"
+VIRTIO_SHA256_DEFAULT="${VIRTIO_SHA256_DEFAULT:-d5b5739cf297f0538d263e30678d5a09bba470a7c6bcbd8dff74e44153f16549}"
+# VIRTIO 0.1.285-1 vsock drivers needed for incus agent => 6.22
+VIRTIO_VERSION_6_22="${VIRTIO_VERSION_6_22:-0.1.285-1}"
+VIRTIO_SHA256_6_22="${VIRTIO_SHA256_6_22:-e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331}"
+
+# auto-select virtio pack based on local incus version (6.22+ needs vsock)
+if [ -z "${VIRTIO_VERSION:-}" ] && command -v incus >/dev/null 2>&1; then
+	_iv=$(incus version 2>/dev/null | awk '/^Client version:/ {print $3; exit}')
+	if [ -n "${_iv}" ] \
+	&& [ "$(printf '6.22\n%s\n' "${_iv}" | sort -V | head -n1)" = "6.22" ]; then
+		VIRTIO_VERSION="${VIRTIO_VERSION_6_22}"
+		VIRTIO_SHA256="${VIRTIO_SHA256_6_22}"
+	fi
+	unset _iv
+fi
+
+VIRTIO_VERSION="${VIRTIO_VERSION:-${VIRTIO_VERSION_DEFAULT}}"
+VIRTIO_SHA256="${VIRTIO_SHA256:-${VIRTIO_SHA256_DEFAULT}}"

--- a/config.sh
+++ b/config.sh
@@ -1,21 +1,23 @@
 VIRTIO_ARCHIVE="${VIRTIO_ARCHIVE:-https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/}"
-# 0.1.262-1 breaks 2012
-VIRTIO_VERSION_DEFAULT="${VIRTIO_VERSION_DEFAULT:-0.1.248-1}"
-VIRTIO_SHA256_DEFAULT="${VIRTIO_SHA256_DEFAULT:-d5b5739cf297f0538d263e30678d5a09bba470a7c6bcbd8dff74e44153f16549}"
-# VIRTIO 0.1.285-1 vsock drivers needed for incus agent => 6.22
-VIRTIO_VERSION_6_22="${VIRTIO_VERSION_6_22:-0.1.285-1}"
-VIRTIO_SHA256_6_22="${VIRTIO_SHA256_6_22:-e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331}"
+
+# Internal virtio packs, not user-overridable.
+# 0.1.262-1 breaks 2012; novsock pack is used for incus < 6.22.
+VIRTIO_VERSION_NOVSOCK="0.1.248-1"
+VIRTIO_SHA256_NOVSOCK="d5b5739cf297f0538d263e30678d5a09bba470a7c6bcbd8dff74e44153f16549"
+# vsock drivers needed for incus agent >= 6.22.
+VIRTIO_VERSION_VSOCK="0.1.285-1"
+VIRTIO_SHA256_VSOCK="e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331"
 
 # auto-select virtio pack based on local incus version (6.22+ needs vsock)
-if [ -z "${VIRTIO_VERSION:-}" ] && command -v incus >/dev/null 2>&1; then
+if [ -z "${VIRTIO_VERSION:-}" ]; then
+	VIRTIO_VERSION="${VIRTIO_VERSION_NOVSOCK}"
+	VIRTIO_SHA256="${VIRTIO_SHA256_NOVSOCK}"
 	_iv=$(incus version 2>/dev/null | awk '/^Client version:/ {print $3; exit}')
-	if [ -n "${_iv}" ] \
-	&& [ "$(printf '6.22\n%s\n' "${_iv}" | sort -V | head -n1)" = "6.22" ]; then
-		VIRTIO_VERSION="${VIRTIO_VERSION_6_22}"
-		VIRTIO_SHA256="${VIRTIO_SHA256_6_22}"
+	_min=$(printf '6.22\n%s\n' "${_iv}" | sort -V | head -n1)
+	if [ "${_min}" = "6.22" ]; then
+		VIRTIO_VERSION="${VIRTIO_VERSION_VSOCK}"
+		VIRTIO_SHA256="${VIRTIO_SHA256_VSOCK}"
 	fi
 	unset _iv
+	unset _min
 fi
-
-VIRTIO_VERSION="${VIRTIO_VERSION:-${VIRTIO_VERSION_DEFAULT}}"
-VIRTIO_SHA256="${VIRTIO_SHA256:-${VIRTIO_SHA256_DEFAULT}}"

--- a/tools/pack.sh
+++ b/tools/pack.sh
@@ -56,6 +56,13 @@ cp -R "${OEM}" "${TMPDIR}/virtio-win-${VERSION}/OEM/"
 cp "${XMLPATH}" "${TMPDIR}/virtio-win-${VERSION}/"
 [ X = X"${LOCAL}" ] || cp -R "${LOCAL}" "${TMPDIR}/virtio-win-${VERSION}/local/"
 
+# strip viosock driver path from staged unattend if absent in the virtio iso
+if [ ! -d "${TMPDIR}/virtio-win-${VERSION}/viosock" ]; then
+	printf '[+] viosock not present in virtio iso, stripping from unattend\n'
+	sed -i '/<!-- VIOSOCK_BEGIN -->/,/<!-- VIOSOCK_END -->/d' \
+		"${TMPDIR}/virtio-win-${VERSION}/$(basename "${XMLPATH}")"
+fi
+
 rm -f "${DESTDIR}/unattended-${VERSION}.iso"
 xorriso -as mkisofs -o "${DESTDIR}/unattended-${VERSION}.iso" -R -J -V STUFF "${TMPDIR}/virtio-win-${VERSION}/"
 

--- a/unattend/10e/Autounattend.xml
+++ b/unattend/10e/Autounattend.xml
@@ -23,6 +23,11 @@
         <PathAndCredentials wcm:action="add" wcm:keyValue="3">
          <Path>E:\vioscsi\w10\amd64</Path>
         </PathAndCredentials>
+        <!-- VIOSOCK_BEGIN -->
+        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+         <Path>E:\viosock\w10\amd64</Path>
+        </PathAndCredentials>
+        <!-- VIOSOCK_END -->
       </DriverPaths>
     </component>
 

--- a/unattend/11e/Autounattend.xml
+++ b/unattend/11e/Autounattend.xml
@@ -23,6 +23,11 @@
         <PathAndCredentials wcm:action="add" wcm:keyValue="3">
          <Path>E:\vioscsi\w11\amd64</Path>
         </PathAndCredentials>
+        <!-- VIOSOCK_BEGIN -->
+        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+         <Path>E:\viosock\w11\amd64</Path>
+        </PathAndCredentials>
+        <!-- VIOSOCK_END -->
       </DriverPaths>
     </component>
 

--- a/unattend/2016/Autounattend.xml
+++ b/unattend/2016/Autounattend.xml
@@ -23,6 +23,11 @@
         <PathAndCredentials wcm:action="add" wcm:keyValue="3">
          <Path>E:\vioscsi\2k16\amd64</Path>
         </PathAndCredentials>
+        <!-- VIOSOCK_BEGIN -->
+        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+         <Path>E:\viosock\2k16\amd64</Path>
+        </PathAndCredentials>
+        <!-- VIOSOCK_END -->
       </DriverPaths>
     </component>
 

--- a/unattend/2019/Autounattend.xml
+++ b/unattend/2019/Autounattend.xml
@@ -23,6 +23,11 @@
         <PathAndCredentials wcm:action="add" wcm:keyValue="3">
          <Path>E:\vioscsi\2k19\amd64</Path>
         </PathAndCredentials>
+        <!-- VIOSOCK_BEGIN -->
+        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+         <Path>E:\viosock\2k19\amd64</Path>
+        </PathAndCredentials>
+        <!-- VIOSOCK_END -->
       </DriverPaths>
     </component>
 

--- a/unattend/2022/Autounattend.xml
+++ b/unattend/2022/Autounattend.xml
@@ -23,6 +23,11 @@
         <PathAndCredentials wcm:action="add" wcm:keyValue="3">
          <Path>E:\vioscsi\2k22\amd64</Path>
         </PathAndCredentials>
+        <!-- VIOSOCK_BEGIN -->
+        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+         <Path>E:\viosock\2k22\amd64</Path>
+        </PathAndCredentials>
+        <!-- VIOSOCK_END -->
       </DriverPaths>
     </component>
 

--- a/unattend/2025/Autounattend.xml
+++ b/unattend/2025/Autounattend.xml
@@ -15,14 +15,19 @@
     <component language="neutral" name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS">
       <DriverPaths>
         <PathAndCredentials wcm:action="add" wcm:keyValue="1">
-         <Path>E:\viostor\2k22\amd64</Path>
+         <Path>E:\viostor\2k25\amd64</Path>
         </PathAndCredentials>
         <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-         <Path>E:\NetKVM\2k22\amd64</Path>
+         <Path>E:\NetKVM\2k25\amd64</Path>
         </PathAndCredentials>
         <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-         <Path>E:\vioscsi\2k22\amd64</Path>
+         <Path>E:\vioscsi\2k25\amd64</Path>
         </PathAndCredentials>
+        <!-- VIOSOCK_BEGIN -->
+        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+         <Path>E:\viosock\2k25\amd64</Path>
+        </PathAndCredentials>
+        <!-- VIOSOCK_END -->
       </DriverPaths>
     </component>
 


### PR DESCRIPTION
Incus agent in version 6.22+ relies on vsock to communicate, which requires viosock driver. Tested the driver in latest stable (285) with win10e, agent works without manual intervention. The edits should be backward compatible (although not tested), if incus version is less 6.22 then the older tested viritio is pulled (248) and viosock driver is never added to the guest win 10. 