### PR TITLE
pack.sh: use KEY=- stdin syntax for incus config set

### DIFF
--- a/tools/pack.sh
+++ b/tools/pack.sh
@@ -82,8 +82,8 @@ incus init "${name}" --empty --vm -c security.secureboot=false -c limits.cpu=4 -
 incus config device set "${name}" root io.bus=virtio-blk
 incus config device add "${name}" iso disk source="${WINDIR}/${WINFILE}" boot.priority=10
 incus config device add "${name}" incusagent disk source="agent:config"
-apparmr | incus config set "${name}" raw.apparmor -
-printf -- '-drive file=%s,index=0,media=cdrom,if=ide -drive file=%s,index=1,media=cdrom,if=ide\n' "${WINDIR}/${WINFILE}" "${DESTDIR}/unattended-${VERSION}.iso" | incus config set "${name}" raw.qemu -
+apparmr | incus config set "${name}" raw.apparmor=-
+printf -- '-drive file=%s,index=0,media=cdrom,if=ide -drive file=%s,index=1,media=cdrom,if=ide\n' "${WINDIR}/${WINFILE}" "${DESTDIR}/unattended-${VERSION}.iso" | incus config set "${name}" raw.qemu=-
 
 if [ X2008 = X"${VERSION}" ]; then
 	incus config set "${name}" security.csm=true


### PR DESCRIPTION
## Summary
- Switch the two `incus config set ... -` calls in `tools/pack.sh` (raw.apparmor, raw.qemu) from `KEY -` to `KEY=-`
- Silences the `the "<key> <value>" syntax is deprecated` warning emitted by incus 7.0.0+ on each call during the VM-launch stage

Fixes #25.

## Test plan
- [x] Built a Windows 10e image end-to-end against this branch on a separate build machine; the two deprecation warning lines no longer appear in the `[+] Launching the VM` output and the build still completes successfully.