### PR TITLE
Enable Secure Boot on the Win11 build VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ Make sure the project's partition has enough storage space.
 - The `./output/` directory will contain the VM's disk image, metadata
   tarball and unattended install ISO.
 
+### Windows 11
+
+Windows 11 Setup requires Secure Boot and a TPM, so the 11e build VM
+is created with `security.secureboot=true` and a `tpm` device. This
+means the host's Incus firmware must support Secure Boot (EDK2/OVMF
+with the Microsoft UEFI certificates enrolled). This is the case for
+the Zabbly packages and the stock Debian/Ubuntu/Fedora EDK2 packages;
+on hosts without such firmware, the 11e build VM will fail to start.
+The resulting image is not affected and can still be launched with
+`security.secureboot=false` like the other versions.
+
 ### Windows Server 2008 R2 SP1
 
 Windows Server 2008 R2 SP1 is EOL since 2020. However, it still used by

--- a/tools/pack.sh
+++ b/tools/pack.sh
@@ -92,6 +92,10 @@ fi
 if [ X11e = X"${VERSION}" ]; then
 	incus config device add "${name}" tpm tpm
 	incus config device set "${name}" root size=60GiB
+	# Win11 Setup gates install on Secure Boot enabled (and the 11e
+	# autounattend has no LabConfig bypass). Enable it on the build VM
+	# only -- the resulting image clones fine with secureboot=false later.
+	incus config set "${name}" security.secureboot=true
 fi
 
 python3 "${PROGBASE}/click.py" "${name}"


### PR DESCRIPTION
Win11 Setup gates install on Secure Boot enabled, and the 11e autounattend has no LabConfig bypass. Enable Secure Boot on the build VM only - the resulting image clones fine with secureboot=false later.