### PR TITLE
Remove per-user Edge appx before sysprep

### DIFF
--- a/oem/sysprep.bat
+++ b/oem/sysprep.bat
@@ -8,4 +8,8 @@ netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" n
 echo netsh advfirewall firewall set rule name="Allow WinRM HTTPS" new action=allow ^>^> %%WINDIR%%\Temp\SetupComplete.log >> %WINDIR%\Setup\Scripts\SetupComplete.cmd
 echo netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new action=allow ^>^> %%WINDIR%%\Temp\SetupComplete.log >> %WINDIR%\Setup\Scripts\SetupComplete.cmd
 
+rem Remove per-user Edge so it can't fail sysprep /generalize. OOBE
+rem reprovisions it on first boot.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-AppxPackage -Name Microsoft.MicrosoftEdge.Stable | Remove-AppxPackage -ErrorAction SilentlyContinue" 2>nul
+
 %WINDIR%\System32\Sysprep\sysprep.exe /generalize /oobe /shutdown /unattend:%1


### PR DESCRIPTION
Edge auto-updates to a per-user build during the unattended install, leaving it installed for the current user but not provisioned for all users. sysprep /generalize then fails with 0x80073cf2 and the build VM hangs at the sysprep error dialog instead of shutting down.

Remove the per-user Edge package first; OOBE reprovisions it from the all-users package on first boot.

No-op on editions without the Chromium Edge appx. `2>nul` for versions w/o appx (2008/2012.)

Issue observed on Server 2022.