### PR TITLE
Make the build scripts portable to non-GNU userland

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ done
 
 [ X-- != X"${1:-}" ] || shift
 
-targets=$(cut -d' ' -f1 "${PROGBASE}/urls.txt" | paste -sd' ')
+targets=$(cut -d' ' -f1 "${PROGBASE}/urls.txt" | paste -s -d ' ' -)
 if [ 1 -ne $# ] && [ 2 -ne $# ]; then
 	usage >&2
 	printf 'available targets: %s\n' "${targets}"
@@ -93,13 +93,22 @@ fi
 ISODIR="${ISODIR:-./isos}"
 OUTDIR="${OUTDIR:-./output/win${VERSION}}"
 
+# portable sha-256: GNU coreutils (sha256sum) on Linux, perl shasum on macOS
+_sha256() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "${1}" | cut -d' ' -f1
+	else
+		shasum -a 256 "${1}" | cut -d' ' -f1
+	fi
+}
+
 # dliso url fname sha256
 dliso() {
 	[ -d "${ISODIR}" ] || mkdir "${ISODIR}"
 
 	[ -f "${ISODIR}/${2}" ] || curl -fSLo "${ISODIR}/${2}" "${1}"
 
-	if [ X"${3}" != X$(sha256sum "${ISODIR}/${2}" | cut -d' ' -f1) ]; then
+	if [ X"${3}" != X$(_sha256 "${ISODIR}/${2}") ]; then
 		die 'error: hash mismatch for %s\n' "${ISODIR}/${2}"
 	fi
 }
@@ -133,6 +142,8 @@ printf '[+] Building image\n'
 mkdir -p "${OUTDIR}"
 
 shift
+# ${@:+"${@}"} rather than "${@}" so an empty arg list does not trip the
+# nounset (set -u) bug in bash 3.2, which is what macOS ships as /bin/sh.
 sh "${PROGBASE}/tools/pack.sh" \
 	"${VERSION}" \
 	"${isopath}" \
@@ -140,7 +151,7 @@ sh "${PROGBASE}/tools/pack.sh" \
 	"${PROGBASE}/oem/" \
 	"${OUTDIR}" \
 	"${xmlpath}" \
-	"${@}"
+	${@:+"${@}"}
 
 
 printf '[+] Generating metadata\n'

--- a/tools/click.py
+++ b/tools/click.py
@@ -57,7 +57,8 @@ print("[+] You may connect to the VM's VGA using the following command")
 print('incus console --type=vga {}'.format(VM))
 n = 0
 while n < 10:
-    o = subprocess.check_output(['incus', 'ls', '-fcsv', '-cns', VM], env={'LANG': 'C'})
+    o = subprocess.check_output(['incus', 'ls', '-fcsv', '-cns', VM],
+                                env={**os.environ, 'LANG': 'C'})
     for ln in o.split(b'\n'):
         if not ln.startswith(f'{VM},'.encode()):
             continue

--- a/tools/pack.sh
+++ b/tools/pack.sh
@@ -59,8 +59,11 @@ cp "${XMLPATH}" "${TMPDIR}/virtio-win-${VERSION}/"
 # strip viosock driver path from staged unattend if absent in the virtio iso
 if [ ! -d "${TMPDIR}/virtio-win-${VERSION}/viosock" ]; then
 	printf '[+] viosock not present in virtio iso, stripping from unattend\n'
-	sed -i '/<!-- VIOSOCK_BEGIN -->/,/<!-- VIOSOCK_END -->/d' \
-		"${TMPDIR}/virtio-win-${VERSION}/$(basename "${XMLPATH}")"
+	# read/transform/write-back instead of sed -i, whose -i semantics
+	# differ between GNU and BSD sed
+	_xml="${TMPDIR}/virtio-win-${VERSION}/$(basename "${XMLPATH}")"
+	sed '/<!-- VIOSOCK_BEGIN -->/,/<!-- VIOSOCK_END -->/d' "${_xml}" >"${_xml}.new"
+	mv "${_xml}.new" "${_xml}"
 fi
 
 rm -f "${DESTDIR}/unattended-${VERSION}.iso"
@@ -107,7 +110,9 @@ printf '[+] Exporting the image\n'
 incus image export "${name}" "${DESTDIR}"
 
 printf '[+] Extracting disk.qcow2\n'
-cat "${DESTDIR}"/*.tar | tar -C "${DESTDIR}" -f- -x --transform s/rootfs.img/disk.qcow2/ rootfs.img
+# extract then rename instead of tar --transform, which is GNU-only
+cat "${DESTDIR}"/*.tar | tar -C "${DESTDIR}" -xf- rootfs.img
+mv "${DESTDIR}/rootfs.img" "${DESTDIR}/disk.qcow2"
 # incus's disk.qcow2 file is not readable (mode=0)
 chmod 0644 "${DESTDIR}/disk.qcow2"
 rm -f "${DESTDIR}"/*.tar


### PR DESCRIPTION
Run `build.sh`/`pack.sh` under a strict POSIX sh and BSD userland (e.g. the bash 3.2 + BSD tools that macOS ships) without changing behavior on Linux:

- `sha256sum` -> `shasum`/`sha256sum`
- `paste -sd' '` -> `paste -s -d ' ' -`
- `"$@" -> ${@:+"$@"}` to sidestep the bash 3.2 nounset bug on empty `$@`
- `sed -i` -> read / transform / write back (GNU vs BSD -i differ)
- `tar --transform` -> extract then `mv` (--transform is GNU-only)

Also merge os.environ into click.py's subprocess env instead of replacing it. The previous `env={'LANG': 'C'}` dropped `PATH`. `incus` was still found on Linux via the default exec path but not when it lives outside `/usr/bin`.

---

I've been using this for a while to drive builds from my macOS laptop against a remote Incus server. (A few other tweaks were necessary as well, but this is the portability piece.)